### PR TITLE
CSS CPU hover bugfix

### DIFF
--- a/css-cpu-hover/README.md
+++ b/css-cpu-hover/README.md
@@ -83,6 +83,10 @@
                 cursor_id = cs[@hplayer];
             }
         }
+    } else {
+        cpu_is_hovered = false;
+        cpu_hover_time = 0;
+        cursor_id = cursors[player];
     }
 
     #define get_new_hovering_player()


### PR DESCRIPTION
Fixes an issue where clicking a CPU's buttons would cause those buttons to become unusable if a player switched to the CPU's player slot